### PR TITLE
Remove Interop container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,53 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 1.3.0 - 2022-10-11
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- [#5](https://github.com/MidnightDesign/automatic-di-module/pull/5) removes the dependency on interop-container
+  and requires `psr/container` instead. This change also requires a minimum version of `^3.11`
+  of [`laminas/laminas-servicemanager`](https://github.com/laminas/laminas-servicemanager/releases/tag/3.11.0), which
+  introduced a forward compatibility layer to replace interop-container.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
+## 1.2.0 - 2021-05-14
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- [#3](https://github.com/MidnightDesign/automatic-di-module/pull/3) adds compatibility for PHP 8.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
 ## 1.1.0 - 2020-11-16
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "container-interop/container-interop": "^1.2",
-        "laminas/laminas-servicemanager": "^3.0",
-        "midnight/automatic-di": "^1.0"
+        "laminas/laminas-servicemanager": "^3.11",
+        "midnight/automatic-di": "^1.0",
+        "psr/container": "^1.1"
     },
     "require-dev": {
         "bnf/phpstan-psr-container": "^1.0",

--- a/src/AutomaticDiAbstractFactory.php
+++ b/src/AutomaticDiAbstractFactory.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Midnight\AutomaticDiModule;
 
-use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\AbstractFactoryInterface;
 use Midnight\AutomaticDi\AutomaticDiContainer;
+use Psr\Container\ContainerInterface;
 
 class AutomaticDiAbstractFactory implements AbstractFactoryInterface
 {

--- a/src/AutomaticDiConfigFactory.php
+++ b/src/AutomaticDiConfigFactory.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Midnight\AutomaticDiModule;
 
-use Interop\Container\ContainerInterface;
 use Midnight\AutomaticDi\AutomaticDiConfig;
+use Psr\Container\ContainerInterface;
 
 class AutomaticDiConfigFactory
 {

--- a/src/AutomaticDiContainerFactory.php
+++ b/src/AutomaticDiContainerFactory.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Midnight\AutomaticDiModule;
 
-use Interop\Container\ContainerInterface;
 use Midnight\AutomaticDi\AutomaticDiConfig;
 use Midnight\AutomaticDi\AutomaticDiContainer;
+use Psr\Container\ContainerInterface;
 
 class AutomaticDiContainerFactory
 {

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace MidnightTest\AutomaticDiModule;
 
-use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\ServiceManager;
 use Midnight\AutomaticDiModule\Module;
 use MidnightTest\AutomaticDiModule\Asset\AlsoDependsOnFooInterface;
@@ -15,6 +14,7 @@ use MidnightTest\AutomaticDiModule\Asset\Foo;
 use MidnightTest\AutomaticDiModule\Asset\FooInterface;
 use MidnightTest\AutomaticDiModule\Asset\NoDependencies;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 
 use function array_merge;
 


### PR DESCRIPTION
* Remove usages of Interop\Container
* require `laminas/laminas-servicemanager` minimum version of `3.11`